### PR TITLE
Refactor to use Arc and Mutex for thread-safe shared ownership

### DIFF
--- a/src/buffer_manager_v2.rs
+++ b/src/buffer_manager_v2.rs
@@ -118,11 +118,11 @@ impl BufferManagerV2 {
         }
     }
 
-    pub fn unpin(&mut self, buffer: &mut BufferV2) {
-        buffer.unpin();
-        if !buffer.is_pinned() {
+    pub fn unpin(&mut self, buffer: &Arc<Mutex<BufferV2>>) {
+        let mut buf = buffer.lock().unwrap();
+        buf.unpin();
+        if !buf.is_pinned() {
             self.number_of_available = self.number_of_available + 1;
-            return;
         }
     }
 
@@ -226,8 +226,7 @@ impl BufferListV2 {
         let mut should_remove_from_buffers = false;
 
         if let Some(buffer) = self.buffers.get(&block_id) {
-            let mut buffer = buffer.lock().unwrap();
-            self.buffer_manager.lock().unwrap().unpin(&mut buffer);
+            self.buffer_manager.lock().unwrap().unpin(buffer);
             // self.pinsから始めに見つかったblock_idを削除
             if let Some(index) = self.pins.iter().position(|x| *x == block_id) {
                 self.pins.remove(index);
@@ -246,8 +245,7 @@ impl BufferListV2 {
     pub fn unpin_all(&mut self) {
         for block_id in self.pins.iter() {
             if let Some(buffer) = self.buffers.get(block_id) {
-                let mut buffer = buffer.lock().unwrap();
-                self.buffer_manager.lock().unwrap().unpin(&mut buffer);
+                self.buffer_manager.lock().unwrap().unpin(buffer);
             }
         }
         self.buffers.clear();
@@ -303,9 +301,8 @@ mod tests {
             page_1.set_string(140, "hello buffer manager");
 
             borrowed_buffer.set_modified(1, 0);
-
-            buffer_manager.lock().unwrap().unpin(&mut borrowed_buffer);
         }
+        buffer_manager.lock().unwrap().unpin(&buffer);
 
         let block_2_id = BlockId::new("test_buffer_manager.txt".to_string(), 1);
         let buffer_2 = buffer_manager.lock().unwrap().pin(block_2_id).unwrap();
@@ -316,10 +313,7 @@ mod tests {
         let block_4_id = BlockId::new("test_buffer_manager.txt".to_string(), 3);
         let _buffer_4 = buffer_manager.lock().unwrap().pin(block_4_id).unwrap();
 
-        buffer_manager
-            .lock()
-            .unwrap()
-            .unpin(&mut buffer_2.lock().unwrap());
+        buffer_manager.lock().unwrap().unpin(&buffer_2);
 
         let block_5_id = BlockId::new("test_buffer_manager.txt".to_string(), 0);
         let buffer_5 = buffer_manager.lock().unwrap().pin(block_5_id).unwrap();

--- a/src/buffer_manager_v2.rs
+++ b/src/buffer_manager_v2.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use crate::file_manager::FileManager;
@@ -10,16 +11,16 @@ pub struct BufferV2 {
     pub tx_num: Option<i32>,
     lsn: Option<i32>,
     pin_count: i32,
-    log_manager: Rc<RefCell<LogManagerV2>>,
-    file_manager: Rc<RefCell<FileManager>>,
+    log_manager: Arc<Mutex<LogManagerV2>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 impl BufferV2 {
     pub fn new(
-        file_manager: Rc<RefCell<FileManager>>,
-        log_manager: Rc<RefCell<LogManagerV2>>,
+        file_manager: Arc<Mutex<FileManager>>,
+        log_manager: Arc<Mutex<LogManagerV2>>,
     ) -> BufferV2 {
-        let page = Page::new(file_manager.borrow().block_size);
+        let page = Page::new(file_manager.lock().unwrap().block_size);
         let pin_count = 0;
 
         BufferV2 {
@@ -59,7 +60,8 @@ impl BufferV2 {
     pub fn assign_to_block(&mut self, block_id: BlockId) {
         self.flush();
         self.file_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .read(&block_id, &mut self.page);
         self.block_id = Some(block_id);
         self.pin_count = 0;
@@ -69,10 +71,12 @@ impl BufferV2 {
         if self.tx_num.is_some() && self.block_id.is_some() {
             let block_id = self.block_id.as_ref().unwrap();
             self.log_manager
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .flush_with_lsn(self.lsn.unwrap_or(-1));
             self.file_manager
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .write(&block_id, &mut self.page);
             self.tx_num = None;
         }
@@ -88,20 +92,20 @@ impl BufferV2 {
 }
 
 pub struct BufferManagerV2 {
-    buffer_pool: Vec<Rc<RefCell<BufferV2>>>,
+    buffer_pool: Vec<Arc<Mutex<BufferV2>>>,
     number_of_available: i32,
-    file_manager: Rc<RefCell<FileManager>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 impl BufferManagerV2 {
     pub fn new(
         number_of_buffer: i32,
-        file_manager: Rc<RefCell<FileManager>>,
-        log_manager: Rc<RefCell<LogManagerV2>>,
+        file_manager: Arc<Mutex<FileManager>>,
+        log_manager: Arc<Mutex<LogManagerV2>>,
     ) -> BufferManagerV2 {
         let mut buffer_pool = Vec::new();
         for _ in 0..number_of_buffer {
-            buffer_pool.push(Rc::new(RefCell::new(BufferV2::new(
+            buffer_pool.push(Arc::new(Mutex::new(BufferV2::new(
                 file_manager.clone(),
                 log_manager.clone(),
             ))));
@@ -124,14 +128,14 @@ impl BufferManagerV2 {
 
     pub fn flush_all(&mut self, tx_num: i32) {
         for buffer in self.buffer_pool.iter() {
-            let mut buffer = buffer.borrow_mut();
+            let mut buffer = buffer.lock().unwrap();
             if buffer.tx_num.is_some() && buffer.tx_num.unwrap() == tx_num {
                 buffer.flush();
             }
         }
     }
 
-    pub fn try_to_pin(&mut self, block_id: BlockId) -> Option<Rc<RefCell<BufferV2>>> {
+    pub fn try_to_pin(&mut self, block_id: BlockId) -> Option<Arc<Mutex<BufferV2>>> {
         let buffer = self.find_existing_buffer(&block_id);
 
         let buffer = match buffer {
@@ -140,7 +144,7 @@ impl BufferManagerV2 {
                 let buffer = self.choose_unpinned_buffer();
                 match buffer {
                     Some(buffer) => {
-                        buffer.borrow_mut().assign_to_block(block_id);
+                        buffer.lock().unwrap().assign_to_block(block_id);
                         Some(buffer)
                     }
                     None => panic!("All buffers are pinned"),
@@ -149,7 +153,7 @@ impl BufferManagerV2 {
         };
 
         if let Some(buffer) = buffer {
-            let mut buffer_mut = buffer.borrow_mut();
+            let mut buffer_mut = buffer.lock().unwrap();
             if !buffer_mut.is_pinned() {
                 self.number_of_available = self.number_of_available - 1;
             }
@@ -160,9 +164,9 @@ impl BufferManagerV2 {
         }
     }
 
-    fn find_existing_buffer(&mut self, block_id: &BlockId) -> Option<Rc<RefCell<BufferV2>>> {
+    fn find_existing_buffer(&mut self, block_id: &BlockId) -> Option<Arc<Mutex<BufferV2>>> {
         let buffer = self.buffer_pool.iter().find(|buffer| {
-            let buffer_ref = buffer.borrow();
+            let buffer_ref = buffer.lock().unwrap();
             buffer_ref.block_id().is_some()
                 && buffer_ref.block_id().as_ref().unwrap().equals(&block_id)
         });
@@ -174,9 +178,9 @@ impl BufferManagerV2 {
         }
     }
 
-    fn choose_unpinned_buffer(&mut self) -> Option<Rc<RefCell<BufferV2>>> {
+    fn choose_unpinned_buffer(&mut self) -> Option<Arc<Mutex<BufferV2>>> {
         let buffer = self.buffer_pool.iter().find(|buffer| {
-            let buffer = buffer.borrow();
+            let buffer = buffer.lock().unwrap();
             !buffer.is_pinned()
         });
 
@@ -187,7 +191,7 @@ impl BufferManagerV2 {
         }
     }
 
-    pub fn pin(&mut self, block_id: BlockId) -> Option<Rc<RefCell<BufferV2>>> {
+    pub fn pin(&mut self, block_id: BlockId) -> Option<Arc<Mutex<BufferV2>>> {
         return self.try_to_pin(block_id);
     }
 
@@ -197,13 +201,13 @@ impl BufferManagerV2 {
 }
 
 pub struct BufferListV2 {
-    buffers: HashMap<BlockId, Rc<RefCell<BufferV2>>>,
+    buffers: HashMap<BlockId, Arc<Mutex<BufferV2>>>,
     pins: Vec<BlockId>,
-    buffer_manager: Rc<RefCell<BufferManagerV2>>,
+    buffer_manager: Arc<Mutex<BufferManagerV2>>,
 }
 
 impl BufferListV2 {
-    pub fn new(buffer_manager: Rc<RefCell<BufferManagerV2>>) -> BufferListV2 {
+    pub fn new(buffer_manager: Arc<Mutex<BufferManagerV2>>) -> BufferListV2 {
         BufferListV2 {
             buffers: HashMap::new(),
             pins: Vec::new(),
@@ -212,8 +216,8 @@ impl BufferListV2 {
     }
 
     pub fn pin(&mut self, block_id: BlockId) {
-        if let Some(buffer) = self.buffer_manager.borrow_mut().pin(block_id.clone()) {
-            self.buffers.insert(block_id.clone(), Rc::clone(&buffer));
+        if let Some(buffer) = self.buffer_manager.lock().unwrap().pin(block_id.clone()) {
+            self.buffers.insert(block_id.clone(), Arc::clone(&buffer));
             self.pins.push(block_id);
         }
     }
@@ -222,8 +226,8 @@ impl BufferListV2 {
         let mut should_remove_from_buffers = false;
 
         if let Some(buffer) = self.buffers.get(&block_id) {
-            let mut buffer = buffer.borrow_mut();
-            self.buffer_manager.borrow_mut().unpin(&mut buffer);
+            let mut buffer = buffer.lock().unwrap();
+            self.buffer_manager.lock().unwrap().unpin(&mut buffer);
             // self.pinsから始めに見つかったblock_idを削除
             if let Some(index) = self.pins.iter().position(|x| *x == block_id) {
                 self.pins.remove(index);
@@ -242,15 +246,15 @@ impl BufferListV2 {
     pub fn unpin_all(&mut self) {
         for block_id in self.pins.iter() {
             if let Some(buffer) = self.buffers.get(block_id) {
-                let mut buffer = buffer.borrow_mut();
-                self.buffer_manager.borrow_mut().unpin(&mut buffer);
+                let mut buffer = buffer.lock().unwrap();
+                self.buffer_manager.lock().unwrap().unpin(&mut buffer);
             }
         }
         self.buffers.clear();
         self.pins.clear();
     }
 
-    pub fn get_buffer(&mut self, block_id: BlockId) -> Option<&Rc<RefCell<BufferV2>>> {
+    pub fn get_buffer(&mut self, block_id: BlockId) -> Option<&Arc<Mutex<BufferV2>>> {
         let buffer = self.buffers.get(&block_id);
         return buffer;
     }
@@ -268,16 +272,16 @@ mod tests {
         let test_dir = std::path::Path::new("test_data");
 
         let block_size = 400;
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
 
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             "log.txt".to_string(),
         )));
 
         let number_of_buffers = 3;
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             number_of_buffers,
             file_manager.clone(),
             log_manager.clone(),
@@ -287,10 +291,10 @@ mod tests {
 
         let block_1_id = BlockId::new(data_file_name.clone(), 0);
 
-        let buffer = buffer_manager.borrow_mut().pin(block_1_id).unwrap();
+        let buffer = buffer_manager.lock().unwrap().pin(block_1_id).unwrap();
 
         {
-            let mut borrowed_buffer = buffer.borrow_mut();
+            let mut borrowed_buffer = buffer.lock().unwrap();
 
             let page_1 = borrowed_buffer.content();
 
@@ -300,26 +304,27 @@ mod tests {
 
             borrowed_buffer.set_modified(1, 0);
 
-            buffer_manager.borrow_mut().unpin(&mut borrowed_buffer);
+            buffer_manager.lock().unwrap().unpin(&mut borrowed_buffer);
         }
 
         let block_2_id = BlockId::new("test_buffer_manager.txt".to_string(), 1);
-        let buffer_2 = buffer_manager.borrow_mut().pin(block_2_id).unwrap();
+        let buffer_2 = buffer_manager.lock().unwrap().pin(block_2_id).unwrap();
 
         let block_3_id = BlockId::new("test_buffer_manager.txt".to_string(), 2);
-        let _buffer_3 = buffer_manager.borrow_mut().pin(block_3_id).unwrap();
+        let _buffer_3 = buffer_manager.lock().unwrap().pin(block_3_id).unwrap();
 
         let block_4_id = BlockId::new("test_buffer_manager.txt".to_string(), 3);
-        let _buffer_4 = buffer_manager.borrow_mut().pin(block_4_id).unwrap();
+        let _buffer_4 = buffer_manager.lock().unwrap().pin(block_4_id).unwrap();
 
         buffer_manager
-            .borrow_mut()
-            .unpin(&mut buffer_2.borrow_mut());
+            .lock()
+            .unwrap()
+            .unpin(&mut buffer_2.lock().unwrap());
 
         let block_5_id = BlockId::new("test_buffer_manager.txt".to_string(), 0);
-        let buffer_5 = buffer_manager.borrow_mut().pin(block_5_id).unwrap();
+        let buffer_5 = buffer_manager.lock().unwrap().pin(block_5_id).unwrap();
 
-        let mut borrowed_buffer_5 = buffer_5.borrow_mut();
+        let mut borrowed_buffer_5 = buffer_5.lock().unwrap();
 
         let content = borrowed_buffer_5.content();
         let value = content.get_integer(80);

--- a/src/concurrency_manager.rs
+++ b/src/concurrency_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, rc::Rc};
 
 use crate::block::BlockId;
@@ -60,11 +61,11 @@ impl LockTable {
 
 pub struct ConcurrencyManagerV2 {
     locks: HashMap<BlockId, String>,
-    lock_table: Rc<RefCell<LockTable>>,
+    lock_table: Arc<Mutex<LockTable>>,
 }
 
 impl ConcurrencyManagerV2 {
-    pub fn new(lock_table: Rc<RefCell<LockTable>>) -> ConcurrencyManagerV2 {
+    pub fn new(lock_table: Arc<Mutex<LockTable>>) -> ConcurrencyManagerV2 {
         let locks: HashMap<BlockId, String> = HashMap::new();
         ConcurrencyManagerV2 { locks, lock_table }
     }
@@ -72,7 +73,7 @@ impl ConcurrencyManagerV2 {
     pub fn s_lock(&mut self, block_id: BlockId) {
         let lock_value = self.locks.get(&block_id);
         if lock_value.is_none() {
-            self.lock_table.borrow_mut().s_lock(block_id.clone());
+            self.lock_table.lock().unwrap().s_lock(block_id.clone());
             self.locks.insert(block_id, "S".to_string());
         }
     }
@@ -80,7 +81,7 @@ impl ConcurrencyManagerV2 {
     pub fn x_lock(&mut self, block_id: BlockId) {
         if !self.has_xlock(&block_id) {
             self.s_lock(block_id.clone());
-            self.lock_table.borrow_mut().x_lock(block_id.clone());
+            self.lock_table.lock().unwrap().x_lock(block_id.clone());
             self.locks.insert(block_id, "X".to_string());
         }
     }
@@ -99,7 +100,7 @@ impl ConcurrencyManagerV2 {
 
     pub fn release(&mut self) {
         for (key, value) in self.locks.iter() {
-            self.lock_table.borrow_mut().unlock(key);
+            self.lock_table.lock().unwrap().unlock(key);
         }
         self.locks.clear();
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,6 @@
-use std::{cell::RefCell, path::Path, rc::Rc};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::{cell::RefCell, rc::Rc};
 
 use crate::{
     buffer_manager_v2::BufferManagerV2, concurrency_manager::LockTable, file_manager::FileManager,
@@ -6,27 +8,27 @@ use crate::{
 };
 
 pub struct Database {
-    lock_table: Rc<RefCell<LockTable>>,
-    log_manager: Rc<RefCell<LogManagerV2>>,
-    buffer_manager: Rc<RefCell<BufferManagerV2>>,
-    file_manager: Rc<RefCell<FileManager>>,
+    lock_table: Arc<Mutex<LockTable>>,
+    log_manager: Arc<Mutex<LogManagerV2>>,
+    buffer_manager: Arc<Mutex<BufferManagerV2>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 impl Database {
     pub fn new(directory_path: &Path) -> Self {
-        let file_manager = Rc::new(RefCell::new(FileManager::new(directory_path, 400)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(directory_path, 400)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             "log.txt".to_string(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             1000,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         Database {
             lock_table,

--- a/src/file_manager.rs
+++ b/src/file_manager.rs
@@ -136,7 +136,7 @@ mod tests {
 
     #[test]
     fn file_lock_blocks_concurrent_access() {
-        let test_dir_name = format!("test_dir_{}", uuid::Uuid::new_v4());
+        let test_dir_name = format!("test_data_{}", uuid::Uuid::new_v4());
         let test_dir = Path::new(&test_dir_name);
         let fm = Arc::new(FileManager::new(test_dir, 400));
         let file_arc = fm.get_file("locktest");

--- a/src/index_join_scan.rs
+++ b/src/index_join_scan.rs
@@ -1,4 +1,9 @@
-use std::{cell::RefCell, path::Path, rc::Rc};
+use std::{
+    cell::RefCell,
+    path::Path,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 use crate::{
     buffer_manager_v2::BufferManagerV2,
@@ -146,19 +151,19 @@ fn test_view_mgr() {
 
     let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-    let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-    let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+    let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+    let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
         file_manager.clone(),
         log_file_name.clone(),
     )));
 
-    let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+    let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
         100,
         file_manager.clone(),
         log_manager.clone(),
     )));
 
-    let lock_table = Rc::new(RefCell::new(LockTable::new()));
+    let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
     let transaction = Rc::new(RefCell::new(TransactionV2::new(
         1,

--- a/src/index_manager.rs
+++ b/src/index_manager.rs
@@ -209,7 +209,12 @@ impl IndexInfo {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use crate::{
         buffer_manager_v2::BufferManagerV2,
@@ -234,19 +239,19 @@ mod tests {
 
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             100,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/log_manager_v2.rs
+++ b/src/log_manager_v2.rs
@@ -7,6 +7,7 @@ use std::{
     os::unix::fs::FileExt,
     path::Path,
     rc::Rc,
+    sync::{Arc, Mutex},
 };
 
 use crate::file_manager::{self, FileManager};
@@ -18,12 +19,12 @@ pub struct LogManagerV2 {
     log_page: Page,
     latest_lsn: i32,
     latest_saved_lsn: i32,
-    file_manager: Rc<RefCell<FileManager>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 impl LogManagerV2 {
-    pub fn new(file_manager: Rc<RefCell<FileManager>>, log_file_name: String) -> LogManagerV2 {
-        let mut file_manager_mut_ref = file_manager.borrow_mut();
+    pub fn new(file_manager: Arc<Mutex<FileManager>>, log_file_name: String) -> LogManagerV2 {
+        let file_manager_mut_ref = file_manager.lock().unwrap();
         let log_size = file_manager_mut_ref.length(&log_file_name);
 
         let mut log_page = Page::new(400);
@@ -50,19 +51,25 @@ impl LogManagerV2 {
     }
 
     pub fn append_new_block(&mut self) -> BlockId {
-        let block_id = self.file_manager.borrow_mut().append(&self.log_file_name);
-        self.log_page = Page::new(self.file_manager.borrow().block_size);
+        let block_id = self
+            .file_manager
+            .lock()
+            .unwrap()
+            .append(&self.log_file_name);
+        self.log_page = Page::new(self.file_manager.lock().unwrap().block_size);
         self.log_page
-            .set_integer(0, self.file_manager.borrow().block_size as i32);
+            .set_integer(0, self.file_manager.lock().unwrap().block_size as i32);
         self.file_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .write(&block_id, &mut self.log_page);
         block_id
     }
 
     pub fn flush(&mut self) {
         self.file_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .write(&self.current_block_id, &mut self.log_page);
 
         self.latest_saved_lsn = self.latest_lsn;
@@ -103,13 +110,13 @@ pub struct LogIteratorV2 {
     current_block_id: BlockId,
     current_offset: usize,
     log_page: Page,
-    file_manager: Rc<RefCell<FileManager>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 impl LogIteratorV2 {
-    fn new(file_manager: Rc<RefCell<FileManager>>, block_id: BlockId) -> LogIteratorV2 {
-        let mut log_page = Page::new(file_manager.borrow().block_size);
-        file_manager.borrow_mut().read(&block_id, &mut log_page);
+    fn new(file_manager: Arc<Mutex<FileManager>>, block_id: BlockId) -> LogIteratorV2 {
+        let mut log_page = Page::new(file_manager.lock().unwrap().block_size);
+        file_manager.lock().unwrap().read(&block_id, &mut log_page);
         let current_offset = log_page.get_integer(0) as usize;
 
         LogIteratorV2 {
@@ -121,19 +128,20 @@ impl LogIteratorV2 {
     }
 
     pub fn has_next(&self) -> bool {
-        self.current_offset < self.file_manager.borrow().block_size
+        self.current_offset < self.file_manager.lock().unwrap().block_size
             || self.current_block_id.get_block_number() > 0
     }
 
     pub fn next(&mut self) -> Vec<u8> {
-        let block_size = self.file_manager.borrow().block_size;
+        let block_size = self.file_manager.lock().unwrap().block_size;
         if block_size == self.current_offset {
             self.current_block_id = BlockId::new(
                 self.current_block_id.get_file_name().to_string(),
                 self.current_block_id.get_block_number() - 1,
             );
             self.file_manager
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .read(&self.current_block_id, &mut self.log_page);
             self.current_offset = self.log_page.get_integer(0) as usize;
         }
@@ -157,9 +165,9 @@ mod tests {
         let test_dir = std::path::Path::new("test_data");
 
         let block_size = 400;
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
 
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             "log.txt".to_string(),
         )));
@@ -171,8 +179,8 @@ mod tests {
         remove_file(test_dir.join("log.txt")).unwrap_or_default();
     }
 
-    fn print_log_records(log_manager: Rc<RefCell<LogManagerV2>>) {
-        let mut log_iterator = log_manager.borrow_mut().iterator();
+    fn print_log_records(log_manager: Arc<Mutex<LogManagerV2>>) {
+        let mut log_iterator = log_manager.lock().unwrap().iterator();
 
         let mut correct_answer_integer = 35;
 
@@ -189,10 +197,10 @@ mod tests {
         }
     }
 
-    fn create_records(start_index: i32, end_index: i32, log_manager: Rc<RefCell<LogManagerV2>>) {
+    fn create_records(start_index: i32, end_index: i32, log_manager: Arc<Mutex<LogManagerV2>>) {
         for i in start_index..end_index {
             let record_data = create_log_record(&format!("record_{}", i), i + 100);
-            let log_sequence_number = log_manager.borrow_mut().append_record(&record_data);
+            let log_sequence_number = log_manager.lock().unwrap().append_record(&record_data);
         }
     }
 

--- a/src/record_page_v2.rs
+++ b/src/record_page_v2.rs
@@ -214,7 +214,13 @@ impl RecordPage {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, fs::remove_file, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        fs::remove_file,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use rand::Rng;
 
@@ -236,19 +242,19 @@ mod tests {
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
         let block_size = 400;
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             3,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/recovery_manager.rs
+++ b/src/recovery_manager.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
@@ -371,17 +372,17 @@ impl LogRecord for RollbackRecord {
 
 pub struct RecoveryManager {
     transaction_number: i32,
-    buffer_manager: Rc<RefCell<BufferManagerV2>>,
-    log_manager: Rc<RefCell<LogManagerV2>>,
+    buffer_manager: Arc<Mutex<BufferManagerV2>>,
+    log_manager: Arc<Mutex<LogManagerV2>>,
 }
 
 impl RecoveryManager {
     pub fn new(
         transaction_number: i32,
-        buffer_manager: Rc<RefCell<BufferManagerV2>>,
-        log_manager: Rc<RefCell<LogManagerV2>>,
+        buffer_manager: Arc<Mutex<BufferManagerV2>>,
+        log_manager: Arc<Mutex<LogManagerV2>>,
     ) -> Self {
-        let _ = StartRecord::write_to_log(&mut log_manager.borrow_mut(), transaction_number);
+        let _ = StartRecord::write_to_log(&mut log_manager.lock().unwrap(), transaction_number);
 
         RecoveryManager {
             transaction_number,
@@ -392,27 +393,31 @@ impl RecoveryManager {
 
     pub fn commit(&self) {
         self.buffer_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .flush_all(self.transaction_number);
-        let lsn =
-            CommitRecord::write_to_log(&mut self.log_manager.borrow_mut(), self.transaction_number);
-        self.log_manager.borrow_mut().flush_with_lsn(lsn);
+        let lsn = CommitRecord::write_to_log(
+            &mut self.log_manager.lock().unwrap(),
+            self.transaction_number,
+        );
+        self.log_manager.lock().unwrap().flush_with_lsn(lsn);
     }
 
     pub fn rollback(&mut self, transaction: &mut InnerTransactionV2) {
         self.do_rollback(transaction);
         self.buffer_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .flush_all(self.transaction_number);
         let lsn = RollbackRecord::write_to_log(
-            &mut self.log_manager.borrow_mut(),
+            &mut self.log_manager.lock().unwrap(),
             self.transaction_number,
         );
-        self.log_manager.borrow_mut().flush_with_lsn(lsn);
+        self.log_manager.lock().unwrap().flush_with_lsn(lsn);
     }
 
     fn do_rollback(&mut self, transaction: &mut InnerTransactionV2) {
-        let mut iterator = self.log_manager.borrow_mut().iterator();
+        let mut iterator = self.log_manager.lock().unwrap().iterator();
         while iterator.has_next() {
             let bytes = iterator.next();
             let log_record = create_log_record(bytes);
@@ -429,7 +434,7 @@ impl RecoveryManager {
     fn do_recover(&mut self, transaction: &mut InnerTransactionV2) {
         let mut finished_transactions = vec![];
 
-        let mut iterator = self.log_manager.borrow_mut().iterator();
+        let mut iterator = self.log_manager.lock().unwrap().iterator();
         while iterator.has_next() {
             let bytes = iterator.next();
             let log_record = create_log_record(bytes);
@@ -450,17 +455,18 @@ impl RecoveryManager {
     fn recover(&mut self, transaction: &mut InnerTransactionV2) {
         self.do_recover(transaction);
         self.buffer_manager
-            .borrow_mut()
+            .lock()
+            .unwrap()
             .flush_all(self.transaction_number);
-        let lsn = CheckpointRecord::write_to_log(&mut self.log_manager.borrow_mut());
-        self.log_manager.borrow_mut().flush_with_lsn(lsn);
+        let lsn = CheckpointRecord::write_to_log(&mut self.log_manager.lock().unwrap());
+        self.log_manager.lock().unwrap().flush_with_lsn(lsn);
     }
 
     pub fn set_integer(&self, offset: usize, buffer: &mut BufferV2) -> i32 {
         let old_value = buffer.content().get_integer(offset);
         let block = buffer.block_id().as_ref().unwrap().clone();
         let lsn = SetIntegerRecord::write_to_log(
-            &mut self.log_manager.borrow_mut(),
+            &mut self.log_manager.lock().unwrap(),
             self.transaction_number,
             &block,
             offset,
@@ -474,7 +480,7 @@ impl RecoveryManager {
         let block = buffer.block_id().as_ref().unwrap().clone();
 
         let lsn = SetStringRecord::write_to_log(
-            &mut self.log_manager.borrow_mut(),
+            &mut self.log_manager.lock().unwrap(),
             self.transaction_number,
             &block,
             offset,

--- a/src/scan_v2.rs
+++ b/src/scan_v2.rs
@@ -293,7 +293,12 @@ impl ScanV2 for ProductScanV2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use crate::{
         buffer_manager_v2::BufferManagerV2,
@@ -318,19 +323,19 @@ mod tests {
 
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             100,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/stat_manager_v2.rs
+++ b/src/stat_manager_v2.rs
@@ -142,7 +142,13 @@ impl StatManagerV2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, fs::remove_file, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        fs::remove_file,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use rand::Rng;
 
@@ -164,19 +170,19 @@ mod tests {
 
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             100,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/table_manager_v2.rs
+++ b/src/table_manager_v2.rs
@@ -276,7 +276,13 @@ impl TableManagerV2 {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, fs::remove_file, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        fs::remove_file,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use crate::{
         buffer_manager_v2::BufferManagerV2,
@@ -295,19 +301,19 @@ mod tests {
 
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             3,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/table_scan_v2.rs
+++ b/src/table_scan_v2.rs
@@ -296,7 +296,13 @@ impl ScanV2 for TableScan {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, fs::remove_file, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        fs::remove_file,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use rand::Rng;
 
@@ -316,19 +322,19 @@ mod tests {
         let block_size = 400;
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             3,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,

--- a/src/transaction_v2.rs
+++ b/src/transaction_v2.rs
@@ -1,3 +1,4 @@
+use std::sync::{Arc, Mutex};
 use std::{cell::RefCell, rc::Rc};
 
 use crate::block::BlockId;
@@ -11,11 +12,11 @@ use crate::{concurrency_manager::ConcurrencyManagerV2, file_manager::FileManager
 
 pub struct InnerTransactionV2 {
     tx_num: i32,
-    buffer_manager: Rc<RefCell<BufferManagerV2>>,
-    lock_table: Rc<RefCell<LockTable>>,
+    buffer_manager: Arc<Mutex<BufferManagerV2>>,
+    lock_table: Arc<Mutex<LockTable>>,
     concurrency_manager: ConcurrencyManagerV2,
     buffer_list: BufferListV2,
-    file_manager: Rc<RefCell<FileManager>>,
+    file_manager: Arc<Mutex<FileManager>>,
 }
 
 pub struct TransactionV2 {
@@ -26,9 +27,9 @@ pub struct TransactionV2 {
 impl InnerTransactionV2 {
     fn new(
         tx_num: i32,
-        file_manager: Rc<RefCell<FileManager>>,
-        buffer_manager: Rc<RefCell<BufferManagerV2>>,
-        lock_table: Rc<RefCell<LockTable>>,
+        file_manager: Arc<Mutex<FileManager>>,
+        buffer_manager: Arc<Mutex<BufferManagerV2>>,
+        lock_table: Arc<Mutex<LockTable>>,
     ) -> InnerTransactionV2 {
         let concurrency_manager = ConcurrencyManagerV2::new(lock_table.clone());
         let buffer_list = BufferListV2::new(buffer_manager.clone());
@@ -44,7 +45,7 @@ impl InnerTransactionV2 {
     }
 
     fn get_block_size(&self) -> usize {
-        self.file_manager.borrow().get_block_size()
+        self.file_manager.lock().unwrap().get_block_size()
     }
 
     pub fn pin(&mut self, block_id: BlockId) {
@@ -78,7 +79,7 @@ impl InnerTransactionV2 {
         self.concurrency_manager.x_lock(block_id.clone());
 
         let buffer = self.buffer_list.get_buffer(block_id).unwrap();
-        let mut buffer = buffer.borrow_mut();
+        let mut buffer = buffer.lock().unwrap();
 
         let mut lsn = -1;
 
@@ -102,7 +103,7 @@ impl InnerTransactionV2 {
         self.concurrency_manager.x_lock(block_id.clone());
 
         let buffer = self.buffer_list.get_buffer(block_id).unwrap();
-        let mut buffer = buffer.borrow_mut();
+        let mut buffer = buffer.lock().unwrap();
 
         if set_to_log {
             recovery_manager.set_string(offset, &mut buffer);
@@ -116,39 +117,39 @@ impl InnerTransactionV2 {
     fn get_integer(&mut self, block_id: BlockId, offset: usize) -> i32 {
         self.concurrency_manager.s_lock(block_id.clone());
         let buffer = self.buffer_list.get_buffer(block_id).unwrap();
-        let mut buffer = buffer.borrow_mut();
+        let mut buffer = buffer.lock().unwrap();
         let page = buffer.content();
         page.get_integer(offset)
     }
 
     fn get_size(&self, file_name: String) -> usize {
-        return self.file_manager.borrow_mut().length(&file_name);
+        return self.file_manager.lock().unwrap().length(&file_name);
     }
 
     fn get_string(&mut self, block_id: BlockId, offset: usize) -> String {
         self.concurrency_manager.s_lock(block_id.clone());
         let buffer = self.buffer_list.get_buffer(block_id).unwrap();
-        let mut buffer = buffer.borrow_mut();
+        let mut buffer = buffer.lock().unwrap();
         let page = buffer.content();
         page.get_string(offset)
     }
 
     fn append(&mut self, file_name: &str) -> BlockId {
-        self.file_manager.borrow_mut().append(file_name)
+        self.file_manager.lock().unwrap().append(file_name)
     }
 
     fn get_available_buffer_size(&self) -> i32 {
-        self.buffer_manager.borrow().get_available_buffer_size()
+        self.buffer_manager.lock().unwrap().get_available_buffer_size()
     }
 }
 
 impl TransactionV2 {
     pub fn new(
         tx_num: i32,
-        file_manager: Rc<RefCell<FileManager>>,
-        buffer_manager: Rc<RefCell<BufferManagerV2>>,
-        lock_table: Rc<RefCell<LockTable>>,
-        log_manager: Rc<RefCell<LogManagerV2>>,
+        file_manager: Arc<Mutex<FileManager>>,
+        buffer_manager: Arc<Mutex<BufferManagerV2>>,
+        lock_table: Arc<Mutex<LockTable>>,
+        log_manager: Arc<Mutex<LogManagerV2>>,
     ) -> TransactionV2 {
         let recovery_manager =
             RecoveryManager::new(tx_num, buffer_manager.clone(), log_manager.clone());
@@ -237,17 +238,17 @@ mod tests {
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
         let block_size = 400;
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             10,
             file_manager.clone(),
             log_manager.clone(),
         )));
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let mut transaction = TransactionV2::new(
             1,

--- a/src/view_manager.rs
+++ b/src/view_manager.rs
@@ -82,7 +82,12 @@ impl ViewManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, path::Path, rc::Rc};
+    use std::{
+        cell::RefCell,
+        path::Path,
+        rc::Rc,
+        sync::{Arc, Mutex},
+    };
 
     use crate::{
         buffer_manager_v2::BufferManagerV2,
@@ -101,19 +106,19 @@ mod tests {
 
         let log_file_name = format!("log_file_{}.txt", uuid::Uuid::new_v4());
 
-        let file_manager = Rc::new(RefCell::new(FileManager::new(test_dir, block_size)));
-        let log_manager = Rc::new(RefCell::new(LogManagerV2::new(
+        let file_manager = Arc::new(Mutex::new(FileManager::new(test_dir, block_size)));
+        let log_manager = Arc::new(Mutex::new(LogManagerV2::new(
             file_manager.clone(),
             log_file_name.clone(),
         )));
 
-        let buffer_manager = Rc::new(RefCell::new(BufferManagerV2::new(
+        let buffer_manager = Arc::new(Mutex::new(BufferManagerV2::new(
             100,
             file_manager.clone(),
             log_manager.clone(),
         )));
 
-        let lock_table = Rc::new(RefCell::new(LockTable::new()));
+        let lock_table = Arc::new(Mutex::new(LockTable::new()));
 
         let transaction = Rc::new(RefCell::new(TransactionV2::new(
             1,


### PR DESCRIPTION
- Updated BufferManagerV2, BufferV2, and related structures to use Arc<Mutex<T>> instead of Rc<RefCell<T>> for better concurrency support.
- Modified the implementation of various methods to lock and unlock the mutex where necessary.
- Adjusted tests and other modules to accommodate the new ownership model.
- Ensured that all instances of shared resources are now safely accessible across threads.